### PR TITLE
Change DNS lookup to account for ipv6 issue

### DIFF
--- a/linuxdyndns.sh
+++ b/linuxdyndns.sh
@@ -17,7 +17,8 @@ INTERVAL=<INSERT INTERVAL>
 dns_ip=$(dig $HOST.$DOMAIN +short) #Check the registered IP in DNS
 while true
 do
-        public_ip=$(dig TXT +short o-o.myaddr.l.google.com @ns1.google.com|awk -F'"' '{print $2}') #Check Public IP
+        # public_ip=$(dig TXT +short o-o.myaddr.l.google.com @ns1.google.com|awk -F'"' '{print $2}') #Check Public IP
+        public_ip=$(dig @resolver4.opendns.com myip.opendns.com +short|awk -F'"' '{print $2}') # Check Public IP
         if [ "$public_ip" != "$dns_ip" ]
         then
                 curl "https://dynamicdns.park-your-domain.com/update?host=$HOST&domain=$DOMAIN&password=$PASSWORD&ip=$public_ip"


### PR DESCRIPTION
I had an issue with the original script, where when looking up against Google's DNS servers I would consistently get an ipv6 address back which is incompatible with the Dynamic DNS record being updated. To correct for this, I updated the lookup to instead check against opendns's servers.

Additionally, this PR changes the mode of linuxdyndns.sh from 644 to 755.